### PR TITLE
Sort packages/files in output

### DIFF
--- a/lib/Devel/Cover/Report/Clover/Package.pm
+++ b/lib/Devel/Cover/Report/Clover/Package.pm
@@ -30,7 +30,7 @@ sub files {
     }
 
     my @ret;
-    foreach my $name ( keys %frag_classes ) {
+    foreach my $name ( sort keys %frag_classes ) {
         my $classes = $frag_classes{$name};
         my $file    = Devel::Cover::Report::Clover::PackageFile->new(
             {   name    => $name,

--- a/lib/Devel/Cover/Report/Clover/Project.pm
+++ b/lib/Devel/Cover/Report/Clover/Project.pm
@@ -6,7 +6,7 @@ use base qw(Devel::Cover::Report::Clover::Reportable);
 sub report {
     my ($self) = @_;
 
-    my @p_reports = map { $_->report } @{ $self->packages };
+    my @p_reports = map { $_->report } sort { $a->name cmp $b->name } @{ $self->packages };
 
     my $data = {
         name     => $self->name(),


### PR DESCRIPTION
Hi,

When using this module with Jenkins Clover plugin, packages and files are not sorted.  I think sorting packages and files is better to look it.

In additon to that, use package name "main" instead of "".
